### PR TITLE
Provide semigroup and monoid instances that build under 8.4.x and 8.2.x and 8.0.x

### DIFF
--- a/MMAP.hsc
+++ b/MMAP.hsc
@@ -6,7 +6,6 @@ module MMAP where
 import           Control.Exception
 import           Control.Monad
 import           Data.Bits ((.|.))
-import           Data.Monoid
 import           Data.Typeable
 import           Foreign.C.Types
 import           Foreign.Ptr
@@ -111,7 +110,9 @@ protNone = ProtOption #const PROT_NONE
 
 instance Monoid ProtOption where
   mempty = protNone
-  mappend (ProtOption a) (ProtOption b) = ProtOption (a .|. b)
+
+instance Semigroup ProtOption where
+  (<>) (ProtOption a) (ProtOption b) = ProtOption (a .|. b)
 
 
 -- | Determines whether updates to the mapping are visible
@@ -218,7 +219,9 @@ mapUninitialized = MmapOptionalFlag #const MAP_UNINITIALIZED
 
 instance Monoid MmapOptionalFlag where
   mempty = MmapOptionalFlag 0
-  mappend (MmapOptionalFlag a) (MmapOptionalFlag b) = MmapOptionalFlag (a .|. b)
+
+instance Semigroup MmapOptionalFlag where
+  (<>) (MmapOptionalFlag a) (MmapOptionalFlag b) = MmapOptionalFlag (a .|. b)
 
 
 -- | An `MmapSharedFlag` with one or more `MmapOptionalFlag`s.

--- a/SharedMemory.hs
+++ b/SharedMemory.hs
@@ -3,7 +3,6 @@ module SharedMemory
   ( openSharedMemory
   ) where
 
-import           Data.Monoid
 import           Foreign.C.Types (CSize)
 import qualified Foreign.Concurrent as FC
 import           Foreign.ForeignPtr

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, base, bytestring, stdenv, unix }:
+mkDerivation {
+  pname = "shared-memory";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [ base unix ];
+  testHaskellDepends = [ base bytestring unix ];
+  homepage = "https://github.com/nh2/shared-memory";
+  description = "POSIX shared memory";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/18_09.nix
+++ b/nix/18_09.nix
@@ -1,0 +1,9 @@
+let
+  fetchNixpkgs = import ./fetchNixpkgs.nix;
+
+in
+  fetchNixpkgs {
+     rev          = "a8ff2616603a6ff6bfb060368c12a973c8e007f6";
+     sha256       = "15l57ra62w9imqv3cfx9qp1fag3mqp95x0hdh81cqjb663qxihlg";
+     outputSha256 = "1nkpbwdx1jgr2pv5arllk6k56h3xc61jal7qi66g21qsx6daf0g3";
+  }

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,49 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 output hash
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+if (0 <= builtins.compareVersions builtins.nixVersion "1.12")
+
+# In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+then (
+  builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    sha256 = outputSha256;
+  })
+
+# This hack should at least work for Nix 1.11
+else (
+  (rec {
+    tarball = import <nix/fetchurl.nix> {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+
+    builtin-paths = import <nix/config.nix>;
+      
+    script = builtins.toFile "nixpkgs-unpacker" ''
+      "$coreutils/mkdir" "$out"
+      cd "$out"
+      "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+    '';
+
+    nixpkgs = builtins.derivation ({
+      name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+      builder = builtins.storePath builtin-paths.shell;
+
+      args = [ script ];
+
+      inherit tarball system;
+
+      tar       = builtins.storePath builtin-paths.tar;
+      gzip      = builtins.storePath builtin-paths.gzip;
+      coreutils = builtins.storePath builtin-paths.coreutils;
+    } // (if null == outputSha256 then { } else {
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = outputSha256;
+    }));
+  }).nixpkgs)

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,21 @@
+let
+
+  config   = { allowUnfree = true; };
+  overlays = [
+    (newPkgs: oldPkgs: rec {
+
+      haskellPackages = oldPkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: {
+          shared-memory = haskellPackagesNew.callPackage ./default.nix { };
+        };
+      };
+
+    })
+  ];
+
+  nixpkgs = import ./nix/18_09.nix;
+  pkgs    = import nixpkgs { inherit config overlays; };
+
+in
+
+  { shared-memory = pkgs.haskellPackages.shared-memory; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).shared-memory.env


### PR DESCRIPTION
To accommodate the new superclass constraints.