### PR TITLE
Add initial slash to follow recomendations

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,7 +25,7 @@ data Person = Person
 
 main :: IO ()
 main = do
-  let shmemPath = "asdf"
+  let shmemPath = "/asdf"
   let size = 200
 
   (fptr, fd) <- openSharedMemory shmemPath


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man3/shm_open.3.html -
> For portable use, a shared memory object should be identified by a name    of the form /somename; that is, a null-terminated string of up to       NAME_MAX (i.e., 255) characters consisting of an initial slash,       followed by one or more characters, none of which are slashes.